### PR TITLE
Fix CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
@@ -258,7 +258,7 @@ jobs:
           done
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-report
           path: build-report.md
@@ -274,7 +274,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   REGISTRY: docker.io
-  NAMESPACE: ${{ secrets.DOCKERHUB_USERNAME || github.repository_owner }}
+  NAMESPACE: ${{ secrets.DOCKER_USERNAME || github.repository_owner }}
 
 jobs:
   # Job to build and test all images
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        database: [postgres, mysql, snowflake, redshift]
+        database: [postgres, mysql, snowflake, redshift, bigquery, alloydb, spanner, neo4j, sqlite, redis, sqlserver, firestore, supabase]
     
     steps:
     - name: Checkout repository
@@ -40,8 +40,8 @@ jobs:
       uses: docker/login-action@v3
       with:
         registry: ${{ env.REGISTRY }}
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
     
     - name: Extract metadata
       id: meta

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -60,7 +60,7 @@ jobs:
           fi
 
       - name: Upload scan results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: trivy-results-${{ matrix.database }}
@@ -127,7 +127,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
@@ -240,7 +240,7 @@ jobs:
           fi
 
       - name: Upload security report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: security-report
           path: security-report.md


### PR DESCRIPTION
Fix CI failures by updating GitHub Actions, standardizing Docker Hub secrets, and expanding the database build matrix.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-6b3e19b3-7ffa-49ea-955e-2a8d77732a60) · [Cursor](https://cursor.com/background-agent?bcId=bc-6b3e19b3-7ffa-49ea-955e-2a8d77732a60)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)